### PR TITLE
Upgrade to Go + Checkout actions v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,17 +14,12 @@ jobs:
 
     steps:
       - name: Install Go
-        uses: actions/setup-go@v1
-        with:
-          go-version: 1.13.x
+        uses: actions/setup-go@v2
 
       - name: Install Golint
         run: go get -u golang.org/x/lint/golint
 
-      - uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
-          path: go/src/github.com/brandur/passages-signup
+      - uses: actions/checkout@v2
 
       - name: Debug
         run: |


### PR DESCRIPTION
Go V1 now seems to be failing, so try an upgrade to V2.